### PR TITLE
Removed datetime serialization

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,17 +12,15 @@
         "axios": "^1.11.0",
         "axios-retry": "^4.5.0",
         "dotenv": "^16.3.1",
-        "luxon": "^3.7.1",
         "nock": "^14.0.10",
         "ts-node": "^10.9.1"
       },
       "devDependencies": {
-        "@types/luxon": "^3.7.1",
         "tsup": "^8.5.0",
         "typescript": "^5.9.2"
       },
       "engines": {
-        "node": ""
+        "node": ">=16.0.0"
       }
     },
     "node_modules/@cspotcode/source-map-support": {
@@ -897,13 +895,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/@types/luxon": {
-      "version": "3.7.1",
-      "resolved": "https://registry.npmjs.org/@types/luxon/-/luxon-3.7.1.tgz",
-      "integrity": "sha512-H3iskjFIAn5SlJU7OuxUmTEpebK6TKB8rxZShDslBMZJ5u9S//KM1sbdAisiSrqwLQncVjnpi2OK2J51h+4lsg==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/@types/node": {
       "version": "20.11.5",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-20.11.5.tgz",
@@ -1610,15 +1601,6 @@
       "resolved": "https://registry.npmjs.org/lodash.sortby/-/lodash.sortby-4.7.0.tgz",
       "integrity": "sha512-HDWXG8isMntAyRF5vZ7xKuEvOhT4AhlRt/3czTSjvGUxjYCBVRQY48ViDHyfYz9VIoBkW4TMGQNapx+l3RUwdA==",
       "dev": true
-    },
-    "node_modules/luxon": {
-      "version": "3.7.1",
-      "resolved": "https://registry.npmjs.org/luxon/-/luxon-3.7.1.tgz",
-      "integrity": "sha512-RkRWjA926cTvz5rAb1BqyWkKbbjzCGchDUIKMCUvNi17j6f6j8uHGDV82Aqcqtzd+icoYpELmG3ksgGiFNNcNg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      }
     },
     "node_modules/magic-string": {
       "version": "0.30.17",

--- a/package.json
+++ b/package.json
@@ -47,7 +47,6 @@
     }
   ],
   "devDependencies": {
-    "@types/luxon": "^3.7.1",
     "tsup": "^8.5.0",
     "typescript": "^5.9.2"
   },
@@ -55,7 +54,6 @@
     "axios": "^1.11.0",
     "axios-retry": "^4.5.0",
     "dotenv": "^16.3.1",
-    "luxon": "^3.7.1",
     "nock": "^14.0.10",
     "ts-node": "^10.9.1"
   },

--- a/src/endpoints/advanced/advanced.interfaces.ts
+++ b/src/endpoints/advanced/advanced.interfaces.ts
@@ -1,13 +1,11 @@
 export interface APIUsageRequest {
-    format?: "JSON", // they also support CSV but not sure how to handle that just yet
-    delimiter?: string,
-    // https://en.wikipedia.org/wiki/List_of_tz_database_time_zones
-    // (we should check against a list before request execution to save time)
-    timezone?: string,
+    format?: "JSON" | "CSV";
+    delimiter?: string;
+    timezone?: string;
 }
 
 export interface APIUsageResponse {
-    timestamp: string,
-    currentUsage: number,
+    timestamp: string;
+    currentUsage: number;
     planLimit: number;
 }

--- a/src/endpoints/advanced/advanced.ts
+++ b/src/endpoints/advanced/advanced.ts
@@ -2,12 +2,10 @@ import type { AxiosInstance } from "axios";
 import { EndpointBase } from "../../defaults";
 import { APIUsageRequest, APIUsageResponse } from "./advanced.interfaces";
 import { Endpoints } from "../endpoints";
-import { globalTransformationManager } from "../../serialization";
 
 export default class Advanced extends EndpointBase {
     constructor(apiClient: AxiosInstance) {
         super(apiClient);
-        registerAPIUsageTransformations();
     }
 
     // Endpoint fetching functions starts here
@@ -16,10 +14,4 @@ export default class Advanced extends EndpointBase {
         const params = this.constructUrlParams(requestConfig, Endpoints.APIUsage);
         return await this.request<APIUsageResponse>(Endpoints.APIUsage, params);
     }
-}
-
-function registerAPIUsageTransformations() {
-    globalTransformationManager.addEndpointConfig(Endpoints.APIUsage, {
-        dateTimeFields: ["timestamp"]
-    });
 }

--- a/src/endpoints/analysis/analysis.ts
+++ b/src/endpoints/analysis/analysis.ts
@@ -26,13 +26,7 @@ import { globalTransformationManager } from "../../serialization";
 export default class Analysis extends EndpointBase {
     constructor(apiClient: AxiosInstance) {
         super(apiClient);
-        registerEPSTrendEstimateTransformations();
-        registerEPSRevisionsEstimateTransformations();
         registerRecommendationsTransformations();
-        registerRevenueEstimateTransformations();
-        registerEarningsEstimateTransformations();
-        registerAnalystRatingsSnapshotTransformations();
-        registerAnalystRatingsUSEquitiesTransformations();
     }
 
     // Endpoint fetching functions starts here
@@ -100,48 +94,11 @@ export default class Analysis extends EndpointBase {
     }
 }
 
-function registerEarningsEstimateTransformations() {
-    globalTransformationManager.addEndpointConfig(Endpoints.EarningsEstimate, {
-        dateFields: ["date"],
-    });
-}
-
-function registerRevenueEstimateTransformations() {
-    globalTransformationManager.addEndpointConfig(Endpoints.RevenueEstimate, {
-        dateFields: ["date"],
-    });
-}
-
 function registerRecommendationsTransformations() {
     globalTransformationManager.addEndpointConfig(Endpoints.Recommendations, {
         responseMappings: {
             "2_months_ago": "twoMonthsAgo",
             "3_months_ago": "threeMonthsAgo",
-        },
-        dateFields: ["date"],
-    });
-}
-
-function registerEPSTrendEstimateTransformations() {
-    globalTransformationManager.addEndpointConfig(Endpoints.EpsTrend, {
-        dateFields: ["date"],
-    });
-}
-
-function registerEPSRevisionsEstimateTransformations() {
-    globalTransformationManager.addEndpointConfig(Endpoints.EpsRevisions, {
-        dateFields: ["date"],
-    });
-}
-
-function registerAnalystRatingsSnapshotTransformations() {
-    globalTransformationManager.addEndpointConfig(Endpoints.AnalystRatingsSnapshot, {
-        dateFields: ["date"],
-    });
-}
-
-function registerAnalystRatingsUSEquitiesTransformations() {
-    globalTransformationManager.addEndpointConfig(Endpoints.AnalystRatingsUsEquities, {
-        dateFields: ["date"],
+        }
     });
 }

--- a/src/endpoints/core/core.interfaces.ts
+++ b/src/endpoints/core/core.interfaces.ts
@@ -35,11 +35,11 @@ export interface TimeSeriesRequest {
     // Timezone for the response (e.g. "America/New_York", "UTC"). Defaults to "Exchange"
     timezone?: string;
     // Specific day to fetch data for (time is ignored)
-    date?: Date;
+    date?: string;
     // Time when the series starts
-    startDate?: Date;
+    startDate?: string;
     // Time when the series ends
-    endDate?: Date;
+    endDate?: string;
     // Include previous close price in the response (default is false)
     previousClose?: boolean;
     // Adjusting mode for prices ("none", "dividends", "splits", "all"). Default is "none"
@@ -52,7 +52,7 @@ export interface TimeSeriesResponse {
 }
 
 export interface TimeSeriesCandle {
-    dateTime: Date;
+    dateTime: string;
     open: string;
     close: string;
     high: string;
@@ -93,9 +93,9 @@ export interface TimeSeriesCrossRequest {
     // Timezone for the response (e.g. "America/New_York", "UTC"). Defaults to "Exchange"
     timezone?: string;
     // Time when the series starts
-    startDate?: Date;
+    startDate?: string;
     // Time when the series ends
-    endDate?: Date;
+    endDate?: string;
     // Specifies if there should be an adjustment (default is true)
     adjust?: boolean;
 
@@ -112,7 +112,7 @@ export interface TimeSeriesCrossMeta {
 }
 
 export interface TimeSeriesCrossValue {
-    dateTime: Date;
+    dateTime: string;
     open: string;
     close: string;
     high: string;
@@ -246,7 +246,7 @@ export interface EndOfDayPriceRequest {
     // The asset class to which the instrument belongs
     type?: AssetClassType;
     // Specific date to fetch data for (time is ignored)
-    date?: Date;
+    date?: string;
     // Include pre- / post-market data (default is false) (only for Pro and above plans)
     prePost?: boolean;
     // Number of decimal places for float values. Supports 0-11, default is 5
@@ -258,8 +258,8 @@ export interface EndOfDayPriceResponse {
     exchange: string;
     micCode?: string;
     currency?: string;
-    dateTime: Date;
-    timestamp: Date;
+    dateTime: string;
+    timestamp: number;
     close: string;
 }
 

--- a/src/endpoints/core/core.ts
+++ b/src/endpoints/core/core.ts
@@ -87,9 +87,7 @@ function registerTimeSeriesTransformations() {
         },
         responseMappings: {
             datetime: "dateTime",
-        },
-        dateFields: ["date"],
-        dateTimeFields: ["startDate", "endDate", "dateTime"]
+        }
     });
 }
 
@@ -101,9 +99,7 @@ function registerTimeSeriesCrossTransformations() {
         },
         responseMappings: {
             datetime: "dateTime",
-        },
-        dateFields: ["date"],
-        dateTimeFields: ["startDate", "endDate", "dateTime"]
+        }
     });
 }
 
@@ -118,7 +114,6 @@ function registerQuoteTransformations() {
             rolling_1d_change: "rollingOneDayChange",
             rolling_7d_change: "rollingSevenDayChange"
         },
-        dateTimeFields: ["dateTime", "timestamp", "lastQuoteAt", "extendedTimestamp"],
     });
 }
 
@@ -135,8 +130,6 @@ function registerEndOfDayPriceTransformations() {
         },
         responseMappings: {
             datetime: "dateTime",
-        },
-        dateFields: ["date"],
-        dateTimeFields: ["dateTime", "timestamp"],
+        }
     });
 }

--- a/src/endpoints/currencies/currencies.ts
+++ b/src/endpoints/currencies/currencies.ts
@@ -7,12 +7,10 @@ import {
     ExchangeRateRequest,
     ExchangeRateResponse
 } from "./currencies.interfaces";
-import { globalTransformationManager } from "../../serialization";
 
 export default class Currencies extends EndpointBase {
     constructor(apiClient: AxiosInstance) {
         super(apiClient);
-        registerCurrencyConversionTransformations();
     }
 
     // Endpoint fetching functions starts here
@@ -26,18 +24,4 @@ export default class Currencies extends EndpointBase {
 
         return this.request<CurrencyConversionResponse>(Endpoints.CurrencyConversion, params);
     }
-}
-
-function registerCurrencyConversionTransformations() {
-    globalTransformationManager.addEndpointConfig(Endpoints.CurrencyConversion, {
-        dateTimeFields: ["timestamp"],
-        dateFields: ["date"],
-    });
-}
-
-function registerExchangeRateTransformations() {
-    globalTransformationManager.addEndpointConfig(Endpoints.ExchangeRate, {
-        dateTimeFields: ["timestamp"],
-        dateFields: ["date"],
-    });
 }


### PR DESCRIPTION
Removed the automatic datetime serialization and return strings/numbers directly from the API instead.

It was a cool idea but unfortunately the TwelveData API doesn't include the timezone in most responses and doesn't ever include an offset (WHY DON'T THEY USE ISO STRINGS AHHH) so it's better to just return the date and time strings as they're received and let the user worry about timezones given their specific context.

Also removed the luxon dependency as it's no longer needed.