### PR TITLE
Added support for CSV response format

### DIFF
--- a/src/endpoints/advanced/advanced.interfaces.ts
+++ b/src/endpoints/advanced/advanced.interfaces.ts
@@ -1,5 +1,4 @@
 export interface APIUsageRequest {
-    format?: "JSON" | "CSV";
     delimiter?: string;
     timezone?: string;
 }

--- a/src/endpoints/advanced/advanced.ts
+++ b/src/endpoints/advanced/advanced.ts
@@ -9,9 +9,11 @@ export default class Advanced extends EndpointBase {
     }
 
     // Endpoint fetching functions starts here
-    async APIUsage(requestConfig?: APIUsageRequest): Promise<APIUsageResponse> {
+    async APIUsage(requestConfig: APIUsageRequest, format: "csv"): Promise<string>;
+    async APIUsage(requestConfig?: APIUsageRequest, format?: "json"): Promise<APIUsageResponse>;
+    async APIUsage(requestConfig?: APIUsageRequest, format?: "json" | "csv"): Promise<APIUsageResponse | string> {
 
         const params = this.constructUrlParams(requestConfig, Endpoints.APIUsage);
-        return await this.request<APIUsageResponse>(Endpoints.APIUsage, params);
+        return await this.requestWithFormat(Endpoints.APIUsage, params, format);
     }
 }

--- a/src/endpoints/core/core.ts
+++ b/src/endpoints/core/core.ts
@@ -71,11 +71,13 @@ export default class Core extends EndpointBase {
         return this.requestWithFormat(Endpoints.LatestPrice, params, format);
     }
 
-    async getEndOfDayPrice(req: EndOfDayPriceRequest): Promise<EndOfDayPriceResponse> {
+    async getEndOfDayPrice(req: EndOfDayPriceRequest, format: "csv"): Promise<string>;
+    async getEndOfDayPrice(req: EndOfDayPriceRequest, format?: "json"): Promise<EndOfDayPriceResponse>;
+    async getEndOfDayPrice(req: EndOfDayPriceRequest, format?: "json" | "csv"): Promise<EndOfDayPriceResponse | string> {
         this.validateRequiredIdentifiers(req);
 
         const params: string = this.constructUrlParams(req, Endpoints.EndOfDayPrice);
-        return this.request<EndOfDayPriceResponse>(Endpoints.EndOfDayPrice, params);
+        return this.requestWithFormat(Endpoints.EndOfDayPrice, params, format);
     }
 }
 

--- a/src/endpoints/currencies/currencies.interfaces.ts
+++ b/src/endpoints/currencies/currencies.interfaces.ts
@@ -4,7 +4,6 @@
 export interface ExchangeRateRequest {
     symbol: string;
     date?: string;
-    format?: "JSON" | "CSV";
     delimiter?: string;
     dp?: number;
     timezone?: string;
@@ -23,7 +22,6 @@ export interface CurrencyConversionRequest {
     symbol: string;
     amount: number;
     date?: string;
-    format?: "JSON" | "CSV";
     delimiter?: string;
     dp?: number;
     timezone?: string;

--- a/src/endpoints/currencies/currencies.ts
+++ b/src/endpoints/currencies/currencies.ts
@@ -14,14 +14,18 @@ export default class Currencies extends EndpointBase {
     }
 
     // Endpoint fetching functions starts here
-    async getExchangeRate(requestConfig: ExchangeRateRequest): Promise<ExchangeRateResponse> {
+    async getExchangeRate(requestConfig: ExchangeRateRequest, format: "csv"): Promise<string>;
+    async getExchangeRate(requestConfig: ExchangeRateRequest, format?: "json"): Promise<ExchangeRateResponse>;
+    async getExchangeRate(requestConfig: ExchangeRateRequest, format?: "json" | "csv"): Promise<ExchangeRateResponse | string> {
         const params = this.constructUrlParams(requestConfig, Endpoints.ExchangeRate);
-        return this.request<ExchangeRateResponse>(Endpoints.ExchangeRate, params);
+        return this.requestWithFormat(Endpoints.ExchangeRate, params, format);
     }
 
-    async getCurrencyConversion(requestConfig: CurrencyConversionRequest): Promise<CurrencyConversionResponse> {
+    async getCurrencyConversion(requestConfig: CurrencyConversionRequest, format: "csv"): Promise<string>;
+    async getCurrencyConversion(requestConfig: CurrencyConversionRequest, format?: "json"): Promise<CurrencyConversionResponse>;
+    async getCurrencyConversion(requestConfig: CurrencyConversionRequest, format?: "json" | "csv"): Promise<CurrencyConversionResponse | string> {
         const params = this.constructUrlParams(requestConfig, Endpoints.CurrencyConversion,);
 
-        return this.request<CurrencyConversionResponse>(Endpoints.CurrencyConversion, params);
+        return this.requestWithFormat(Endpoints.CurrencyConversion, params, format);
     }
 }

--- a/src/endpoints/fundamentals/fundamental.interfaces.ts
+++ b/src/endpoints/fundamentals/fundamental.interfaces.ts
@@ -199,7 +199,6 @@ export interface EarningsRequest {
     type?: SecurityType;
     period?: "latest" | "next";
     outputSize?: number;
-    format?: "JSON" | "CSV";
     delimiter?: string;
     dp?: number;
     startDate?: string;
@@ -234,7 +233,6 @@ export interface EarningsCalendarRequest {
     exchange?: string;
     micCode?: string;
     country?: string;
-    format?: "JSON" | "CSV";
     delimiter?: string;
     dp?: number;
     startDate?: string;

--- a/src/endpoints/fundamentals/fundamentals.ts
+++ b/src/endpoints/fundamentals/fundamentals.ts
@@ -67,13 +67,15 @@ export default class Fundamentals extends EndpointBase {
         return this.request<DividendsResponse>(Endpoints.Dividends, params);
     }
 
-    async getDividendsCalendar(requestConfig?: DividendsCalendarRequest): Promise<DividendsCalendarResponse> {
+    async getDividendsCalendar(requestConfig: DividendsCalendarRequest, format: "csv"): Promise<string>;
+    async getDividendsCalendar(requestConfig?: DividendsCalendarRequest, format?: "json"): Promise<DividendsCalendarResponse>;
+    async getDividendsCalendar(requestConfig?: DividendsCalendarRequest, format?: "json" | "csv"): Promise<DividendsCalendarResponse | string> {
         if (requestConfig) {
             this.validateRequiredIdentifiers(requestConfig);
         }
 
         const params = this.constructUrlParams(requestConfig, Endpoints.DividendsCalendar);
-        return this.request<DividendsCalendarResponse>(Endpoints.DividendsCalendar, params);
+        return this.requestWithFormat(Endpoints.DividendsCalendar, params, format);
     }
 
     async getSplits(requestConfig: SplitsRequest): Promise<SplitsResponse> {
@@ -92,16 +94,20 @@ export default class Fundamentals extends EndpointBase {
         return this.request<SplitsCalendarResponse>(Endpoints.SplitsCalendar, params);
     }
 
-    async getEarnings(requestConfig: EarningsRequest): Promise<EarningsResponse> {
+    async getEarnings(requestConfig: EarningsRequest, format: "csv"): Promise<string>;
+    async getEarnings(requestConfig: EarningsRequest, format?: "json"): Promise<EarningsResponse>;
+    async getEarnings(requestConfig: EarningsRequest, format?: "json" | "csv"): Promise<EarningsResponse | string> {
         this.validateRequiredIdentifiers(requestConfig);
 
         const params = this.constructUrlParams(requestConfig, Endpoints.Earnings);
-        return this.request<EarningsResponse>(Endpoints.Earnings, params);
+        return this.requestWithFormat(Endpoints.Earnings, params, format);
     }
 
-    async getEarningsCalendar(requestConfig?: EarningsCalendarRequest): Promise<EarningsCalendarResponse> {
+    async getEarningsCalendar(requestConfig: EarningsCalendarRequest, format: "csv"): Promise<string>;
+    async getEarningsCalendar(requestConfig?: EarningsCalendarRequest, format?: "json"): Promise<EarningsCalendarResponse>;
+    async getEarningsCalendar(requestConfig?: EarningsCalendarRequest, format?: "json" | "csv"): Promise<EarningsCalendarResponse | string> {
         const params = this.constructUrlParams(requestConfig, Endpoints.EarningsCalendar);
-        return this.request<EarningsCalendarResponse>(Endpoints.EarningsCalendar, params);
+        return this.requestWithFormat(Endpoints.EarningsCalendar, params, format);
     }
 
     async getIpoCalendar(requestConfig?: IPOCalendarRequest): Promise<IPOCalendarResponse> {

--- a/src/endpoints/reference/assetCatalogs/assetCatalogs.interfaces.ts
+++ b/src/endpoints/reference/assetCatalogs/assetCatalogs.interfaces.ts
@@ -13,7 +13,6 @@ export interface StocksRequest {
     micCode?: string;
     country?: string;
     type?: SecurityType;
-    format?: "JSON" | "CSV";
     delimiter?: string;
     showPlan?: boolean;
     includeDelisted?: boolean;
@@ -49,7 +48,6 @@ export interface ForexPairsRequest {
     symbol?: string;
     currencyBase?: string;
     currencyQuote?: string;
-    format?: "JSON" | "CSV";
     delimiter?: string;
 }
 
@@ -72,7 +70,6 @@ export interface CryptocurrencyPairsRequest {
     exchange?: string;
     currencyBase?: string;
     currencyQuote?: string;
-    format?: "JSON" | "CSV";
     delimiter?: string;
 }
 
@@ -98,7 +95,6 @@ export interface ETFsRequest {
     exchange?: string;
     micCode?: string;
     country?: string;
-    format?: "JSON" | "CSV";
     delimiter?: string;
     showPlan?: boolean;
     includeDelisted?: boolean;
@@ -135,7 +131,6 @@ export interface FundsRequest {
     cusip?: string;
     exchange?: string;
     country?: string;
-    format?: "JSON" | "CSV";
     delimiter?: string;
     showPlan?: boolean;
     page?: number;
@@ -173,7 +168,6 @@ export interface FundsResponse {
 export interface CommoditiesRequest {
     symbol?: string;
     category?: string;
-    format?: "JSON" | "CSV";
     delimiter?: string;
 }
 
@@ -195,7 +189,6 @@ export interface FixedIncomeRequest {
     symbol?: string;
     exchange?: string;
     country?: string;
-    format?: "JSON" | "CSV";
     delimiter?: string;
     showPlan?: boolean;
     page?: number;

--- a/src/endpoints/reference/assetCatalogs/assetCatalogs.ts
+++ b/src/endpoints/reference/assetCatalogs/assetCatalogs.ts
@@ -25,43 +25,57 @@ export default class AssetCatalogs extends EndpointBase {
     }
 
     // Endpoint fetching functions starts here
-    async getStocks(requestConfig?: StocksRequest): Promise<StocksResponse> {
+    async getStocks(requestConfig: StocksRequest, format: "csv"): Promise<string>;
+    async getStocks(requestConfig?: StocksRequest, format?: "json"): Promise<StocksResponse>;
+    async getStocks(requestConfig?: StocksRequest, format?: "json" | "csv"): Promise<StocksResponse | string> {
         const params = this.constructUrlParams(requestConfig, Endpoints.Stocks);
-        return this.request<StocksResponse>(Endpoints.Stocks, params);
+        return this.requestWithFormat(Endpoints.Stocks, params, format);
     }
 
-    async getEtfs(requestConfig?: ETFsRequest): Promise<ETFsResponse> {
+    async getEtfs(requestConfig: ETFsRequest, format: "csv"): Promise<string>;
+    async getEtfs(requestConfig?: ETFsRequest, format?: "json"): Promise<ETFsResponse>;
+    async getEtfs(requestConfig?: ETFsRequest, format?: "json" | "csv"): Promise<ETFsResponse | string> {
         if (requestConfig) {
             this.validateRequiredIdentifiers(requestConfig);
         }
 
         const params = this.constructUrlParams(requestConfig, Endpoints.ETFs);
-        return this.request<ETFsResponse>(Endpoints.ETFs, params);
+        return this.requestWithFormat(Endpoints.ETFs, params, format);
     }
 
-    async getForexPairs(requestConfig?: ForexPairsRequest): Promise<ForexPairResponse> {
+    async getForexPairs(requestConfig: ForexPairsRequest, format: "csv"): Promise<string>;
+    async getForexPairs(requestConfig?: ForexPairsRequest, format?: "json"): Promise<ForexPairResponse>;
+    async getForexPairs(requestConfig?: ForexPairsRequest, format?: "json" | "csv"): Promise<ForexPairResponse | string> {
         const params = this.constructUrlParams(requestConfig, Endpoints.ForexPairs);
-        return this.request<ForexPairResponse>(Endpoints.ForexPairs, params);
+        return this.requestWithFormat(Endpoints.ForexPairs, params, format);
     }
 
-    async getCryptocurrencyPairs(requestConfig?: CryptocurrencyPairsRequest): Promise<CryptocurrencyPairsResponse> {
+    async getCryptocurrencyPairs(requestConfig: CryptocurrencyPairsRequest, format: "csv"): Promise<string>;
+    async getCryptocurrencyPairs(requestConfig?: CryptocurrencyPairsRequest, format?: "json"): Promise<CryptocurrencyPairsResponse>;
+    async getCryptocurrencyPairs(requestConfig?: CryptocurrencyPairsRequest, format?: "json" | "csv"): Promise<CryptocurrencyPairsResponse | string> {
         const params = this.constructUrlParams(requestConfig, Endpoints.Cryptocurrencies);
-        return this.request<CryptocurrencyPairsResponse>(Endpoints.Cryptocurrencies, params);
+        return this.requestWithFormat(Endpoints.Cryptocurrencies, params, format);
     }
 
-    async getFunds(requestConfig?: FundsRequest): Promise<FundsResponse> {
+    async getFunds(requestConfig: FundsRequest, format: "csv"): Promise<string>;
+    async getFunds(requestConfig?: FundsRequest, format?: "json"): Promise<FundsResponse>;
+    async getFunds(requestConfig?: FundsRequest, format?: "json" | "csv"): Promise<FundsResponse | string> {
         const params = this.constructUrlParams(requestConfig, Endpoints.Funds);
-        return this.request<FundsResponse>(Endpoints.Funds, params);
+        return this.requestWithFormat(Endpoints.Funds, params, format);
     }
 
-    async getCommodities(requestConfig?: CommoditiesRequest): Promise<CommoditiesResponse> {
+    async getCommodities(requestConfig: CommoditiesRequest, format: "csv"): Promise<string>;
+    async getCommodities(requestConfig?: CommoditiesRequest, format?: "json"): Promise<CommoditiesResponse>;
+    async getCommodities(requestConfig?: CommoditiesRequest, format?: "json" | "csv"): Promise<CommoditiesResponse | string> {
         const params = this.constructUrlParams(requestConfig, Endpoints.Commodities);
-        return this.request<CommoditiesResponse>(Endpoints.Commodities, params);
+        return this.requestWithFormat(Endpoints.Commodities, params, format);
     }
 
-    async getFixedIncome(requestConfig?: FixedIncomeRequest): Promise<FixedIncomeResponse> {
+    async getFixedIncome(requestConfig: FixedIncomeRequest, format: "csv"): Promise<string>;
+    async getFixedIncome(requestConfig?: FixedIncomeRequest, format?: "json"): Promise<FixedIncomeResponse>;
+    async getFixedIncome(requestConfig?: FixedIncomeRequest, format?: "json" | "csv"): Promise<FixedIncomeResponse | string> {
         const params = this.constructUrlParams(requestConfig, Endpoints.Bonds);
-        return this.request<FixedIncomeResponse>(Endpoints.Bonds, params);
+        return this.requestWithFormat(Endpoints.Bonds, params, format);
     }
 
 }

--- a/src/endpoints/reference/markets/markets.interfaces.ts
+++ b/src/endpoints/reference/markets/markets.interfaces.ts
@@ -12,7 +12,6 @@ export interface ExchangesRequest {
     name?: string;
     code?: string;
     country?: string;
-    format?: "JSON" | "CSV";
     delimiter?: string;
     showPlan?: boolean;
 }
@@ -68,7 +67,6 @@ export interface ExchangeScheduleResponse {
  /cryptocurrency_exchanges
  */
 export interface CryptocurrencyExchangesRequest {
-    format?: "JSON" | "CSV";
     delimiter?: string;
 }
 

--- a/src/endpoints/reference/markets/markets.ts
+++ b/src/endpoints/reference/markets/markets.ts
@@ -18,23 +18,31 @@ export default class Markets extends EndpointBase {
     }
 
     // Endpoint fetching functions starts here
-    async getExchanges(requestConfig: ExchangesRequest): Promise<ExchangesResponse> {
+    async getExchanges(requestConfig: ExchangesRequest, format: "csv"): Promise<string>;
+    async getExchanges(requestConfig: ExchangesRequest, format?: "json"): Promise<ExchangesResponse>;
+    async getExchanges(requestConfig: ExchangesRequest, format?: "json" | "csv"): Promise<ExchangesResponse | string> {
         const params = this.constructUrlParams(requestConfig, Endpoints.Exchanges);
-        return this.request<ExchangesResponse>(Endpoints.Exchanges, params);
+        return this.requestWithFormat(Endpoints.Exchanges, params, format);
     }
 
-    async getExchangeSchedule(requestConfig: ExchangeScheduleRequest): Promise<ExchangeScheduleResponse> {
+    async getExchangeSchedule(requestConfig: ExchangeScheduleRequest, format: "csv"): Promise<string>;
+    async getExchangeSchedule(requestConfig: ExchangeScheduleRequest, format?: "json"): Promise<ExchangeScheduleResponse>;
+    async getExchangeSchedule(requestConfig: ExchangeScheduleRequest, format?: "json" | "csv"): Promise<ExchangeScheduleResponse | string> {
         const params = this.constructUrlParams(requestConfig, Endpoints.ExchangeSchedule);
-        return this.request<ExchangeScheduleResponse>(Endpoints.ExchangeSchedule, params);
+        return this.requestWithFormat(Endpoints.ExchangeSchedule, params, format);
     }
 
-    async getCryptocurrencyExchanges(requestConfig?: CryptocurrencyExchangesRequest): Promise<CryptocurrencyExchangesResponse> {
+    async getCryptocurrencyExchanges(requestConfig: CryptocurrencyExchangesRequest, format: "csv"): Promise<string>;
+    async getCryptocurrencyExchanges(requestConfig?: CryptocurrencyExchangesRequest, format?: "json"): Promise<CryptocurrencyExchangesResponse>;
+    async getCryptocurrencyExchanges(requestConfig?: CryptocurrencyExchangesRequest, format?: "json" | "csv"): Promise<CryptocurrencyExchangesResponse | string> {
         const params = this.constructUrlParams(requestConfig, Endpoints.CryptocurrencyExchanges);
-        return this.request<CryptocurrencyExchangesResponse>(Endpoints.CryptocurrencyExchanges, params);
+        return this.requestWithFormat(Endpoints.CryptocurrencyExchanges, params, format);
     }
 
-    async getMarketState(requestConfig?: MarketStateRequest): Promise<MarketStateResponse> {
+    async getMarketState(requestConfig: MarketStateRequest, format: "csv"): Promise<string>;
+    async getMarketState(requestConfig?: MarketStateRequest, format?: "json"): Promise<MarketStateResponse>;
+    async getMarketState(requestConfig?: MarketStateRequest, format?: "json" | "csv"): Promise<MarketStateResponse | string> {
         const params = this.constructUrlParams(requestConfig, Endpoints.MarketState);
-        return this.request<MarketStateResponse>(Endpoints.MarketState, params);
+        return this.requestWithFormat(Endpoints.MarketState, params, format);
     }
 }


### PR DESCRIPTION
Added support for CSV response format to all endpoints that support it. Supported endpoint functions take in an optional argument "format" that can be either CSV or JSON (default). TypeScript properly infers the return type based on the selected format.